### PR TITLE
Always capture command output

### DIFF
--- a/auto/test
+++ b/auto/test
@@ -2,4 +2,4 @@
 set -Eeuo pipefail
 
 docker build -t typo-tests .
-docker run -e OPENAI_API_KEY -t typo-tests npx cucumber-js --format summary
+docker run -e OPENAI_API_KEY -t typo-tests npx cucumber-js --fail-fast --format summary

--- a/features/base.feature
+++ b/features/base.feature
@@ -6,7 +6,6 @@ Feature: Basic terminal commands
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     When typo has finished running
-    Then stderr should be empty
     And the last line of the output should equal "hello"
 
     Examples:
@@ -22,14 +21,12 @@ Feature: Basic terminal commands
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     When typo has finished running
-    Then stderr should be empty
     And the current directory should be "/"
 
     When the user runs "typo actually lets go to home dir"
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     When typo has finished running
-    Then stderr should be empty
     And the current directory should be "/home/node"
 
     When the user runs "typo switch to my movies folder"
@@ -38,14 +35,12 @@ Feature: Basic terminal commands
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     When typo has finished running
-    Then stderr should be empty
     And the current directory should be "/home/node/MovieFolder"
 
     When the user runs "typo nah I prefer the previous folder we were in"
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     When typo has finished running
-    Then stderr should be empty
     And the current directory should be "/home/node"
 
     Examples:
@@ -62,42 +57,36 @@ Feature: Basic terminal commands
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     When typo has finished running
-    Then stderr should be empty
     And the current directory should be "/home/node/test"
 
     When the user runs "typo make a fib.csv file with the top row containing the first 10 fibonacci numbers"
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     When typo has finished running
-    Then stderr should be empty
     And "/home/node/test/fib.csv" should contain exactly "0,1,1,2,3,5,8,13,21,34"
 
     When the user runs "typo now add one to each of the numbers"
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     And typo has finished running
-    Then stderr should be empty
     And "/home/node/test/fib.csv" should contain exactly "1,2,2,3,4,6,9,14,22,35"
 
     When the user runs "typo now duplicate the first line twice so there are exactly three lines"
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     And typo has finished running
-    Then stderr should be empty
     And "/home/node/test/fib.csv" should contain exactly "1,2,2,3,4,6,9,14,22,35\n1,2,2,3,4,6,9,14,22,35\n1,2,2,3,4,6,9,14,22,35"
 
     When the user runs "typo replace the 9 on the second line with 'prawn'"
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     And typo has finished running
-    Then stderr should be empty
     And "/home/node/test/fib.csv" should contain exactly "1,2,2,3,4,6,9,14,22,35\n1,2,2,3,4,6,prawn,14,22,35\n1,2,2,3,4,6,9,14,22,35"
 
     When the user runs "typo convert the whole thing to a json array using raw integers where possible and save to fib.json"
     Then typo should ask the user for confirmation to run a command
     When the user grants permission
     And typo has finished running
-    Then stderr should be empty
     And "/home/node/test/fib.json" should contain exactly "[[1,2,2,3,4,6,9,14,22,35],[1,2,2,3,4,6,\"prawn\",14,22,35],[1,2,2,3,4,6,9,14,22,35]]"
 
     Examples:

--- a/features/support/steps.js
+++ b/features/support/steps.js
@@ -114,16 +114,13 @@ Then('the last line of the output should equal {string}', function (expectedOutp
 
 Then('the current directory should be {string}', function (expectedOutput, callback) {
   run_command(`pwd`);
-  setTimeout(() => {
-    try {
-      const lastLine = output.trimEnd().split('\n').pop();
-      assert.equal(lastLine, expectedOutput);
-      output = '';
-      callback();
-    } catch (err) {
-      callback(err);
-    }
-  }, 100);
+  const timeout = 10000; // 10 seconds overall timeout
+
+  const inExpectedDirectory = () => {
+    const lastLine = output.trimEnd().split('\n').pop();
+    return (lastLine == expectedOutput);
+  }
+  pollUntil(inExpectedDirectory, callback, timeout, 'Timeout: typo did not finish running in time.');
 });
 
 Then('{string} should contain exactly {string}', function (file, contents, callback) {

--- a/features/support/steps.js
+++ b/features/support/steps.js
@@ -45,20 +45,11 @@ When('the user runs {string}', function (command) {
   run_command(`${command}`);
 });
 
-Then('stderr should be empty', function (callback) {
-  try {
-    assert.equal(errorOutput, '', 'Expected stderr to be empty, but some error output was found');
-    callback();
-  } catch (err) {
-    callback(err);
-  }
-});
-
 Then('typo should ask the user for confirmation to run a command', function(callback) {
-  output = '';
+  errorOutput = '';
 
   const confirmationRequested = () => {
-    const lastLine = output.trimEnd().split('\n').pop().trim();
+    const lastLine = errorOutput.trimEnd().split('\n').pop().trim();
     return lastLine == "Run this command (y/n)?";
   }
 

--- a/src/active_prompts/base.txt
+++ b/src/active_prompts/base.txt
@@ -5,42 +5,43 @@ You are an AI agent whose sole purpose is to output a terminal command based on 
 - You should NEVER guess the names of files or directories.
 - You should NEVER assume you know the name of a directory without searching for it first.
 - The terminal command used to invoke yourself is `typo`.
-- ALWAYS follow the examples below to satisfy my requests
-- ALWAYS wait for my response to the first command before replying with the second command, and so on.
+- ALWAYS follow the examples below to satisfy my requests.
+- ALWAYS respond with A SINGLE STEP ONLY. If there is more than one step, you must wait for my response, and then do the next step ONLY AFTER receiving my response.
 
 Examples:
 
-"Go to my home directory"
-1. cd ~
+1. User says: "Go to my home directory"
+2. You respond with: cd ~
 
-"Go to filesystem root"
-1. cd /
+1. User says: "Go to filesystem root"
+2. You respond with: cd /
 
-"Go to my movies directory"
-1. typo $(fdfind . ~ -u --max-depth 7 --exclude Library | fzf -f "movie | film" --scheme=path | head -n 30)
-*decide which directory is most likely to be my main movies directory*
-2. cd ABSOLUTE/PATH/TO/MOVIES_DIR
+1. User says: "Go to my movies directory"
+2. You respond with: typo $(fdfind . ~ --max-depth 7 --exclude Library | fzf -f "movie | film" --scheme=path | head -n 30)
+3. User responds with the command output, use it to decide which directory is most likely to be their main movies directory
+4. You respond with: cd ABSOLUTE/PATH/TO/MOVIES_DIR
 
-"Search online for cat videos"
-1. open "https://www.google.com/search?q=cats&tbm=vid"
+1. User says: "Search online for cat videos"
+2. You respond with: open "https://www.google.com/search?q=cats&tbm=vid"
 
-"Where is my code directory"
-1. typo $(fdfind . ~ -u --max-depth 7 --exclude Library | fzf -f "code | work | git | repo" --scheme=path | head -n 30)
-*decide which directory is most likely to be my main code directory*
-2. # ABSOLUTE/PATH/TO/CODE_DIR
+1. User says: "Where is my code directory"
+2. You respond with: typo $(fdfind . ~ --max-depth 7 --exclude Library | fzf -f "code | work | git | repo" --scheme=path | head -n 30)
+3. User responds with the command output, use it to decide which directory is most likely to be their main code directory
+4. You respond with: # ABSOLUTE/PATH/TO/CODE_DIR
 
-"Where do I keep my git repos"
-1. typo $(fdfind -g ".git" ~ -u --max-depth 7 --exclude Library | sed -e "s/\/[^\/]*\/[^\/]*\/$//" | sort | uniq -c)
-*identify all directories that I have intentionally put a git repo into*
-2. # ABSOLUTE/PATH/TO/REPO1
-   # ABSOLUTE/PATH/TO/REPO2
-   # ETC
+1. User says: "Where do I keep my git repos"
+2. You respond with: typo $(fdfind -g ".git" ~ -u --max-depth 7 --exclude Library | sed -e "s/\/[^\/]\/[^\/]*\/$//" | sort | uniq -c)
+3. User responds with the command output, use it to identify all directories that I have intentionally put a git repo into
+4. You respond with: # ABSOLUTE/PATH/TO/REPO1
+                     # ABSOLUTE/PATH/TO/REPO2
+                     # ETC
 
-"What services are in the docker compose file"
-*decide which directory I'm talking about*
-1. typo $(ls DIRECTORY | grep "compose")
-*decide which is the correct docker compose file*
-2. typo $(cat DOCKER_COMPOSE_FILE)
-3. # SERVICE_1
-   # SERVICE_2
-   # ETC
+1. User says: "What services are in the docker compose file"
+2. You decide which directory the user is talking about
+3. You respond with: typo $(ls DIRECTORY | grep "compose")
+4. User responds with the command output, use it to decide which is the correct docker compose file
+5. You respond with: typo $(cat DOCKER_COMPOSE_FILE)
+6. User responds with the command output, use it to analyse the docker file
+7. You respond with: # SERVICE_1
+                     # SERVICE_2
+                     # ETC

--- a/src/typo.sh
+++ b/src/typo.sh
@@ -27,17 +27,6 @@ typo_get_user_confirmation() {
 function typo() {
     echo "true" > ~/.typo_running
 
-    local unsafe_mode=0
-
-    # Check for --unsafe flag
-    for arg in "$@"; do
-        if [ "$arg" = "--unsafe" ]; then
-            unsafe_mode=1
-            shift
-            break
-        fi
-    done
-
     if ! command -v jq &>/dev/null; then
         echo "jq is not installed"
         return 1
@@ -124,7 +113,7 @@ function typo() {
     if [[ "$returned_command" =~ ^# ]]; then
         echo ""
     else
-        if [ "$unsafe_mode" -eq 1 ]; then
+        if [ "${TYPO_UNSAFE_MODE:-0}" -eq 1 ]; then
             eval "$returned_command"
         else
             echo "Run this command (y/n)?"

--- a/src/typo.sh
+++ b/src/typo.sh
@@ -105,18 +105,18 @@ function typo() {
     fi
 
     local returned_command=$(printf "%s" "$response" | jq -r '.choices[0].message.content')
-    printf "%s\n" "$returned_command"
+    printf "%s\n" "$returned_command" >&2
 
     local returned_command_json="{\"role\": \"assistant\", \"content\": $(jq -Rn --arg content "$returned_command" '$content')}"
     TYPO_CONVERSATION_HISTORY=$(jq -c ". + [$returned_command_json]" <<< "$messages")
 
     if [[ "$returned_command" =~ ^# ]]; then
-        echo ""
+        echo "" >&2
     else
         if [ "${TYPO_UNSAFE_MODE:-0}" -eq 1 ]; then
             eval "$returned_command"
         else
-            echo "Run this command (y/n)?"
+            echo "Run this command (y/n)?" >&2
             if typo_get_user_confirmation; then
                 eval "$returned_command"
             else


### PR DESCRIPTION
Redirects stdout while command is running, and tees it to a temp file. This avoids piping or process substitution which allows `typo` to see the command's output without running the command in a subshell (which would break commands like `cd`). 

The output still makes it to the user's terminal in real time. However, some apps will recognise the output as not being a terminal, e.g:
```
typo open vim
vim
Run this command (y/n)?
y
Vim: Warning: Output is not to a terminal
```

But they still seem to work OK.

Other changes:
- Impement UNSAFE_MODE as an environment variable rather than command line option. This allows it to cascade to sub-calls of typo
- Print command confirmation to stderr instead of stdout, so that `typo` can produce clean stdout from the command it runs
- Improve prompts by making the conversation flow more explicit